### PR TITLE
Avoid creating a list for iterators.

### DIFF
--- a/gitlab_submodule/gitlab_submodule.py
+++ b/gitlab_submodule/gitlab_submodule.py
@@ -4,12 +4,13 @@ from gitlab import Gitlab
 from gitlab.v4.objects import Project, ProjectManager
 
 from gitlab_submodule.objects import Submodule, Subproject
-from gitlab_submodule.read_gitmodules import list_project_submodules
+from gitlab_submodule.read_gitmodules import list_project_submodules, iterate_project_submodules
 from gitlab_submodule.submodule_to_project import submodule_to_project
 from gitlab_submodule.submodule_commit import get_submodule_commit
 
 
 list_submodules = list_project_submodules
+iterate_submodules = iterate_project_submodules
 
 
 def _get_project_manager(
@@ -50,7 +51,7 @@ def iterate_subprojects(
         get_latest_commit_possible_if_not_found: bool = False,
         get_latest_commit_possible_ref: Optional[str] = None
 ) -> Generator[Subproject, None, None]:
-    for gitmodules_submodule in list_project_submodules(project, ref):
+    for gitmodules_submodule in iterate_project_submodules(project, ref):
         try:
             yield submodule_to_subproject(
                 gitmodules_submodule,

--- a/gitlab_submodule/read_gitmodules.py
+++ b/gitlab_submodule/read_gitmodules.py
@@ -10,10 +10,10 @@ from gitlab_submodule.objects import Submodule
 def list_project_submodules(
         project: Project,
         ref: Optional[str] = None) -> List[Submodule]:
-    return list(_get_project_submodules(project, ref))
+    return list(iterate_project_submodules(project, ref))
 
 
-def _get_project_submodules(
+def iterate_project_submodules(
         project: Project,
         ref: Optional[str] = None) -> Iterable[Submodule]:
     gitmodules_file_content = _get_gitmodules_file_content(project, ref)
@@ -41,7 +41,7 @@ def _get_gitmodules_file_content(project: Project,
 
 
 def _read_gitmodules_file_content(
-        gitmodules_file_content: str) -> List[Tuple[str, str, str]]:
+        gitmodules_file_content: str) -> Iterable[Tuple[str, str, str]]:
     """Some basic regex extractions to parse content of .gitmodules file
     """
     name_regex = r'\[submodule "([a-zA-Z0-9\.\-/_]+)"\]'
@@ -52,4 +52,4 @@ def _read_gitmodules_file_content(
     urls = re.findall(url_regex, gitmodules_file_content)
     if not (len(names) == len(paths) == len(urls)):
         raise RuntimeError('Failed parsing the .gitmodules content')
-    return list(zip(names, urls, paths))
+    return zip(names, urls, paths)


### PR DESCRIPTION
Use iterator directly instead of converting it to a list which destroys all performance advantage.