### PR TITLE
[PATCH] Make sure to fetch all pages

### DIFF
--- a/gitlab_submodule/submodule_commit.py
+++ b/gitlab_submodule/submodule_commit.py
@@ -57,7 +57,7 @@ def _get_submodule_commit_id(
     update_submodule_commit = project.commits.get(last_commit_id)
 
     submodule_commit_regex = r'Subproject commit ([a-zA-Z0-9]+)\n'
-    for diff_file in update_submodule_commit.diff():
+    for diff_file in update_submodule_commit.diff(as_list=False):
         if diff_file['new_path'] == submodule_path:
             # either the commit id was added for the first time,
             # or it was updated -> we can find one or two matches


### PR DESCRIPTION
By default, Gitlab pagination only fetches the first 20 results. If the submodule diff is not part of the first 20 files, it won't be detected. The Gitlab python client has a nice feature to handle this automatically and only when needed when you use the _generator_ call. See [documentation](https://python-gitlab.readthedocs.io/en/stable/api-usage.html#pagination).