### PR TITLE
[PATCH] Return None when the submodule commit is not contained in the diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Gitlab project, and more importantly to get the commits they're pointing to.
 Internally, it reads and parses the `.gitmodules` file at the root of the 
 Project. To get the commit id of a submodule, it finds the last commit that 
 updated the submodule and parses its diff (this can sometimes fail due to a 
-[limit of the GitLab API itself](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits) - see [Limitations](Limitations)).
+[limit of the GitLab API itself](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits)
+- see [Limitations](#limitations)).
 
 ---
 **About the future of this package**
@@ -129,7 +130,7 @@ iterate_subprojects(
     self_managed_gitlab_host: Optional[str] = None
 ) -> Generator[Subproject, None, None]
 ```
-####Parameters:
+#### Parameters:
 - `project`: a `gitlab.v4.objects.Project` object
 - `gitlab`: the `gitlab.Gitlab` instance that you used to authenticate, or its 
   `projects: gitlab.v4.objects.ProjectManager` attribute
@@ -143,10 +144,10 @@ iterate_subprojects(
   self-managed GitLab instance, you should pass its url here otherwise it 
   may be impossible to know from the URL that it's a GitLab project.
 
-####Returns:
+#### Returns:
 Generator of `Subproject` objects
 
-####Limitations:
+#### Limitations:
 - due to https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits,
   some very large commit diffs won't be parsed entirely. This means that when 
   inspecting the diff of the latest commit that updated `./<submodule_dir>`,
@@ -167,7 +168,7 @@ returns a `list` of [`Subproject`](#class-subproject) objects.
 ### class `Subproject`
 Basic objects that contain the info about a Gitlab subproject.
 
-####Attributes:
+#### Attributes:
 - `project: Optional[gitlab.v4.objects.Project]`: the Gitlab project that the 
   submodule links to (can be `None` if the submodule is not hosted on GitLab)
 - `submodule: `[`Submodule`](#class-submodule): a basic object that contains 
@@ -176,7 +177,7 @@ Basic objects that contain the info about a Gitlab subproject.
   the submodule points to (if the submodule is not hosted on GitLab, it will 
   be a dummy `Commit` object with a single attribute `id`)
 
-####Example `str()` output:
+#### Example `str()` output:
 ```
 <class 'Subproject'> => {
     'submodule': <class 'Submodule'> => {'name': 'share/extensions', 'parent_project': <class 'gitlab.v4.objects.projects.Project'> => {'id': 3472737, 'description': 'Inkscape vector image editor', 'name': 'inkscape', 'name_with_namespace': 'Inkscape / inkscape', 'path': 'inkscape', 'path_with_namespace': 'inkscape/inkscape', 'created_at': '2017-06-09T14:16:35.615Z', 'default_branch': 'master', 'tag_list': [], 'topics': [], 'ssh_url_to_repo': 'git@gitlab.com:inkscape/inkscape.git', 'http_url_to_repo': 'https://gitlab.com/inkscape/inkscape.git', 'web_url': 'https://gitlab.com/inkscape/inkscape', 'readme_url': 'https://gitlab.com/inkscape/inkscape/-/blob/master/README.md', 'avatar_url': 'https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png', 'forks_count': 900, 'star_count': 2512, 'last_activity_at': '2022-01-29T23:45:49.894Z', 'namespace': {'id': 470642, 'name': 'Inkscape', 'path': 'inkscape', 'kind': 'group', 'full_path': 'inkscape', 'parent_id': None, 'avatar_url': '/uploads/-/system/group/avatar/470642/inkscape.png', 'web_url': 'https://gitlab.com/groups/inkscape'}}, 'parent_ref': 'e371b2f826adcba316f2e64bbf2f697043373d0b', 'path': 'share/extensions', 'url': 'https://gitlab.com/inkscape/extensions.git'},
@@ -194,12 +195,12 @@ list_project_submodules(
     project: Project,
     ref: Optional[str] = None) -> List[Submodule]
 ```
-####Parameters:
+#### Parameters:
 - `project`: a `gitlab.v4.objects.Project` object
 - `ref`: (optional) a ref to a branch, commit, tag etc. Defaults to the 
   HEAD of the project default branch.
 
-####Returns:
+#### Returns:
 `list` of `Submodule` objects
 
 ---
@@ -208,7 +209,7 @@ list_project_submodules(
 Represents the `.gitmodules` config of a submodule + adds info about the 
 parent project
 
-####Attributes:
+#### Attributes:
 - `parent_project: gitlab.v4.objects.Project`: project that uses the submodule
 - `parent_ref: str`: ref where the `.gitmodules` file was read
 - `name: str`: local name used by git for the submodule
@@ -216,7 +217,7 @@ parent project
 - `url: str`: URL linking to the location of the repo of the submodule (not 
   necessarily Gitlab)
 
-####Example `str()` output:
+#### Example `str()` output:
 ```
 <class 'Submodule'> => {'name': 'share/extensions', 'parent_project': <class 'gitlab.v4.objects.projects.Project'> => {'id': 3472737, 'description': 'Inkscape vector image editor', 'name': 'inkscape', 'name_with_namespace': 'Inkscape / inkscape', 'path': 'inkscape', 'path_with_namespace': 'inkscape/inkscape', 'created_at': '2017-06-09T14:16:35.615Z', 'default_branch': 'master', 'tag_list': [], 'topics': [], 'ssh_url_to_repo': 'git@gitlab.com:inkscape/inkscape.git', 'http_url_to_repo': 'https://gitlab.com/inkscape/inkscape.git', 'web_url': 'https://gitlab.com/inkscape/inkscape', 'readme_url': 'https://gitlab.com/inkscape/inkscape/-/blob/master/README.md', 'avatar_url': 'https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png', 'forks_count': 900, 'star_count': 2512, 'last_activity_at': '2022-01-29T23:45:49.894Z', 'namespace': {'id': 470642, 'name': 'Inkscape', 'path': 'inkscape', 'kind': 'group', 'full_path': 'inkscape', 'parent_id': None, 'avatar_url': '/uploads/-/system/group/avatar/470642/inkscape.png', 'web_url': 'https://gitlab.com/groups/inkscape'}}, 'parent_ref': 'e371b2f826adcba316f2e64bbf2f697043373d0b', 'path': 'share/extensions', 'url': 'https://gitlab.com/inkscape/extensions.git'}
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Gitlab project, and more importantly to get the commits they're pointing to.
 Internally, it reads and parses the `.gitmodules` file at the root of the 
 Project. To get the commit id of a submodule, it finds the last commit that 
 updated the submodule and parses its diff (this can sometimes fail due to a 
-[limit of the GitLab API itself](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits)
-- see [Limitations](#limitations)).
+[limit of the GitLab API itself](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits) - 
+see [Limitations](#limitations)).
 
 ---
 **About the future of this package**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Gitlab project, and more importantly to get the commits they're pointing to.
 
 Internally, it reads and parses the `.gitmodules` file at the root of the 
 Project. To get the commit id of a submodule, it finds the last commit that 
-updated the submodule and parses its diff.
+updated the submodule and parses its diff (this can sometimes fail due to a 
+[limit of the GitLab API itself](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits) - see [Limitations](Limitations)).
 
 ---
 **About the future of this package**
@@ -75,7 +76,7 @@ for subproject in subprojects:
     print('- {} ({}) -> {}'.format(
         subproject.submodule.path, 
         subproject.project.web_url, 
-        subproject.commit.id))
+        subproject.commit.id if subproject.commit else '?'))
 ```
 Output:
 ```
@@ -95,13 +96,16 @@ for subproject in subprojects:
 -    print('- {} ({}) -> {}'.format(
 -        subproject.submodule.path, 
 -        subproject.project.web_url, 
--        subproject.commit.id))
+-        subproject.commit.id if subproject.commit else '?'))
 +    head_subproject_commit = subproject.project.commits.list(
 +        ref=subproject.project.default_branch)[0]
-+    up_to_date = subproject.commit.id == head_subproject_commit.id
-+    print('- {}: {}'.format(
-+        subproject.submodule.path,
-+        'ok' if up_to_date else '/!\\ must update'))
++    if subproject.commit is None:  # can happen with very large commit diffs
++        status = 'cannot check'
++    elif subproject.commit.id == head_subproject_commit.id:
++        status = 'ok'
++    else:
++        status = '/!\\ must update'
++    print('- {}: {}'.format(subproject.submodule.path, status))
 
 ```
 Output:
@@ -125,7 +129,7 @@ iterate_subprojects(
     self_managed_gitlab_host: Optional[str] = None
 ) -> Generator[Subproject, None, None]
 ```
-Parameters:
+####Parameters:
 - `project`: a `gitlab.v4.objects.Project` object
 - `gitlab`: the `gitlab.Gitlab` instance that you used to authenticate, or its 
   `projects: gitlab.v4.objects.ProjectManager` attribute
@@ -139,16 +143,31 @@ Parameters:
   self-managed GitLab instance, you should pass its url here otherwise it 
   may be impossible to know from the URL that it's a GitLab project.
 
-Returns: Generator of `Subproject` objects
+####Returns:
+Generator of `Subproject` objects
+
+####Limitations:
+- due to https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits,
+  some very large commit diffs won't be parsed entirely. This means that when 
+  inspecting the diff of the latest commit that updated `./<submodule_dir>`,
+  in some rare cases `./<submodule_dir>` might not be part of the diff 
+  object returned by the GitLab API. In that case we have no other choice than 
+  set `Subproject.commit` to `None`, that's why the two examples above 
+  check if `subproject.commit` is not `None` before using the value 
+  `subproject.commit.id`.
+
+---
 
 ### `list_subprojects(...)`
 Same parameters as [`iterate_subprojects(...)`](#iterate_subprojects) but 
 returns a `list` of [`Subproject`](#class-subproject) objects.
 
+---
+
 ### class `Subproject`
 Basic objects that contain the info about a Gitlab subproject.
 
-Attributes:
+####Attributes:
 - `project: Optional[gitlab.v4.objects.Project]`: the Gitlab project that the 
   submodule links to (can be `None` if the submodule is not hosted on GitLab)
 - `submodule: `[`Submodule`](#class-submodule): a basic object that contains 
@@ -157,7 +176,7 @@ Attributes:
   the submodule points to (if the submodule is not hosted on GitLab, it will 
   be a dummy `Commit` object with a single attribute `id`)
 
-Example `str()` output:
+####Example `str()` output:
 ```
 <class 'Subproject'> => {
     'submodule': <class 'Submodule'> => {'name': 'share/extensions', 'parent_project': <class 'gitlab.v4.objects.projects.Project'> => {'id': 3472737, 'description': 'Inkscape vector image editor', 'name': 'inkscape', 'name_with_namespace': 'Inkscape / inkscape', 'path': 'inkscape', 'path_with_namespace': 'inkscape/inkscape', 'created_at': '2017-06-09T14:16:35.615Z', 'default_branch': 'master', 'tag_list': [], 'topics': [], 'ssh_url_to_repo': 'git@gitlab.com:inkscape/inkscape.git', 'http_url_to_repo': 'https://gitlab.com/inkscape/inkscape.git', 'web_url': 'https://gitlab.com/inkscape/inkscape', 'readme_url': 'https://gitlab.com/inkscape/inkscape/-/blob/master/README.md', 'avatar_url': 'https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png', 'forks_count': 900, 'star_count': 2512, 'last_activity_at': '2022-01-29T23:45:49.894Z', 'namespace': {'id': 470642, 'name': 'Inkscape', 'path': 'inkscape', 'kind': 'group', 'full_path': 'inkscape', 'parent_id': None, 'avatar_url': '/uploads/-/system/group/avatar/470642/inkscape.png', 'web_url': 'https://gitlab.com/groups/inkscape'}}, 'parent_ref': 'e371b2f826adcba316f2e64bbf2f697043373d0b', 'path': 'share/extensions', 'url': 'https://gitlab.com/inkscape/extensions.git'},
@@ -166,6 +185,8 @@ Example `str()` output:
 }
 ```
 
+---
+
 ### `list_submodules(...)`
 Lists the info about the project submodules found in the `.gitmodules` file.
 ```python
@@ -173,18 +194,21 @@ list_project_submodules(
     project: Project,
     ref: Optional[str] = None) -> List[Submodule]
 ```
-Parameters:
+####Parameters:
 - `project`: a `gitlab.v4.objects.Project` object
 - `ref`: (optional) a ref to a branch, commit, tag etc. Defaults to the 
   HEAD of the project default branch.
 
-Returns: list of `Submodule` objects
+####Returns:
+`list` of `Submodule` objects
+
+---
 
 ### class `Submodule`
 Represents the `.gitmodules` config of a submodule + adds info about the 
 parent project
 
-Attributes:
+####Attributes:
 - `parent_project: gitlab.v4.objects.Project`: project that uses the submodule
 - `parent_ref: str`: ref where the `.gitmodules` file was read
 - `name: str`: local name used by git for the submodule
@@ -192,10 +216,12 @@ Attributes:
 - `url: str`: URL linking to the location of the repo of the submodule (not 
   necessarily Gitlab)
 
-Example `str()` output:
+####Example `str()` output:
 ```
 <class 'Submodule'> => {'name': 'share/extensions', 'parent_project': <class 'gitlab.v4.objects.projects.Project'> => {'id': 3472737, 'description': 'Inkscape vector image editor', 'name': 'inkscape', 'name_with_namespace': 'Inkscape / inkscape', 'path': 'inkscape', 'path_with_namespace': 'inkscape/inkscape', 'created_at': '2017-06-09T14:16:35.615Z', 'default_branch': 'master', 'tag_list': [], 'topics': [], 'ssh_url_to_repo': 'git@gitlab.com:inkscape/inkscape.git', 'http_url_to_repo': 'https://gitlab.com/inkscape/inkscape.git', 'web_url': 'https://gitlab.com/inkscape/inkscape', 'readme_url': 'https://gitlab.com/inkscape/inkscape/-/blob/master/README.md', 'avatar_url': 'https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png', 'forks_count': 900, 'star_count': 2512, 'last_activity_at': '2022-01-29T23:45:49.894Z', 'namespace': {'id': 470642, 'name': 'Inkscape', 'path': 'inkscape', 'kind': 'group', 'full_path': 'inkscape', 'parent_id': None, 'avatar_url': '/uploads/-/system/group/avatar/470642/inkscape.png', 'web_url': 'https://gitlab.com/groups/inkscape'}}, 'parent_ref': 'e371b2f826adcba316f2e64bbf2f697043373d0b', 'path': 'share/extensions', 'url': 'https://gitlab.com/inkscape/extensions.git'}
 ```
+
+---
 
 ### `submodule_to_subproject(...)`
 Converts a `Submodule` object to a [`Subproject`](#class-subproject) object, assuming it's 
@@ -204,7 +230,7 @@ hosted on Gitlab.
 Raises a `FileNotFoundError` if the path of the submodule actually doesn't 
 exist in the host repo or if the url of the submodule doesn't link to an 
 existing repo (both can happen if you modify the `.gitmodules` file without 
-using one of the `git submodule` commands)
+using one of the `git submodule` commands).
 
 ```python
 submodule_to_subproject(
@@ -215,6 +241,7 @@ submodule_to_subproject(
 ```
 Parameter details: See [`iterate_subprojects(...)`](#iterate_subprojects)
 
+---
 
 ## Contributing
 

--- a/gitlab_submodule/objects.py
+++ b/gitlab_submodule/objects.py
@@ -61,7 +61,7 @@ class Subproject:
     def __init__(self,
                  submodule: Submodule,
                  project: Optional[Project],
-                 commit: Union[ProjectCommit, Commit, None]):
+                 commit: Optional[Union[ProjectCommit, Commit]]):
         self.submodule = submodule
         self.project = project
         self.commit = commit

--- a/gitlab_submodule/objects.py
+++ b/gitlab_submodule/objects.py
@@ -61,7 +61,7 @@ class Subproject:
     def __init__(self,
                  submodule: Submodule,
                  project: Optional[Project],
-                 commit: Union[ProjectCommit, Commit]):
+                 commit: Union[ProjectCommit, Commit, None]):
         self.submodule = submodule
         self.project = project
         self.commit = commit

--- a/gitlab_submodule/submodule_commit.py
+++ b/gitlab_submodule/submodule_commit.py
@@ -11,12 +11,15 @@ from gitlab_submodule.objects import Submodule, Commit
 def get_submodule_commit(
         submodule: Submodule,
         submodule_project: Optional[Project] = None,
- ) -> Union[ProjectCommit, Commit]:
+ ) -> Union[ProjectCommit, Commit, None]:
     commit_id = _get_submodule_commit_id(
         submodule.parent_project,
         submodule.path,
         submodule.parent_ref,
     )
+    if commit_id is None:
+        return None
+
     if submodule_project is not None:
         commit = submodule_project.commits.get(commit_id)
     else:
@@ -67,6 +70,6 @@ def _get_submodule_commit_id(
             if len(matches) == 1:
                 return matches[0]
 
-    # should never happen
-    raise RuntimeError(f'Did not find any commit id for submodule '
-                       f'"{submodule_path}" at url "{project.web_url}"')
+    # diff can't be retrieved probably because it was too big
+    # see https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits
+    return None


### PR DESCRIPTION
I hit another limitation of the Gitlab API. In my case, the [limit to generate diffs](https://docs.gitlab.com/ee/development/diffs.html#diff-collection-limits) was at 1000 files changed in a single commit in my installation (probably default). I would prefer to return `None` in this case together with the successfully retrieved information like url instead of raising an exception as this will cause the whole iterator to fail.