### PR TITLE
[PATCH] Fix typo in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ a thumb up: https://gitlab.com/gitlab-org/gitlab/-/issues/352836
 
 ## Install
 ```
-pip install python-gitlab-gitmodule
+pip install python-gitlab-submodule
 ```
 or directly from Github:
 ```


### PR DESCRIPTION
Fix the package name typo for install instructions