### PR TITLE
[MINOR] Add support for the remainder of .gitmodules attributes

### DIFF
--- a/gitlab_submodule/objects.py
+++ b/gitlab_submodule/objects.py
@@ -12,15 +12,27 @@ class Submodule:
                  parent_ref: str,
                  name: str,
                  path: str,
-                 url: str):
+                 url: str,
+                 branch: Optional[str]=None,
+                 ignore: Optional[str]=None,
+                 update: Optional[str]=None,
+                 recurse: bool=False,
+                 shallow: bool=False):
+
         self.parent_project = parent_project
         self.parent_ref = parent_ref
         self.name = name
         self.path = path
         self.url = url
+        self.branch = branch
+        self.ignore = ignore
+        self.update = update
+        self.recurse = recurse
+        self.shallow = shallow
 
     def keys(self):
-        return {'parent_project', 'parent_ref', 'name', 'path', 'url'}
+        return {'parent_project', 'parent_ref', 'name', 'path', 'url', 
+                'update', 'branch', 'ignore', 'shallow', 'recurse'}
 
     def __getitem__(self, key):
         if key in self.keys():
@@ -31,24 +43,29 @@ class Submodule:
     def __str__(self):
         keys = sorted(self.keys())
         class_part = f"<class '{self.__class__.__name__}'>"
-
         def to_str(key):
             if isinstance(self[key], str):
                 return f"'{self[key]}'"
             else:
                 return str(self[key])
-
         attributes = [f"'{key}': {to_str(key)}" for key in keys]
         return class_part + ' => {' + ', '.join(attributes) + '}'
 
     def __repr__(self):
-        return '{} ({}, {}, {}, {}, {})'.format(
+        return '{} ({})'.format(
             self.__class__.__name__,
-            repr(self.parent_project),
-            f"'{self.parent_ref}'",
-            f"'{self.name}'",
-            f"'{self.path}'",
-            f"'{self.url}'",
+            ", ".join((
+                repr(self.parent_project),
+                repr(self.parent_ref),
+                repr(self.name),
+                repr(self.path),
+                repr(self.url),
+                repr(self.branch),
+                repr(self.ignore),
+                repr(self.update),
+                repr(self.recurse),
+                repr(self.shallow),
+            ))
         )
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -38,12 +38,15 @@ class TestObjects(unittest.TestCase):
             parent_ref='main',
             name='test_submodule',
             url='git@gitlab.com:test/submodule',
-            path='include/test_submodule'
+            path='include/test_submodule',
+            update='rebase'
         )
         submodule_dict = dict(submodule)
-        self.assertEqual(len(submodule_dict.keys()), 5)
+        self.assertEqual(len(submodule_dict.keys()), 10)
         self.assertEqual(submodule_dict['parent_ref'], 'main')
         self.assertEqual(submodule_dict['name'], 'test_submodule')
+        self.assertEqual(submodule_dict['update'], 'rebase')
+        self.assertEqual(submodule_dict['branch'], None)
 
     def test_Submodule_str(self):
         mock_project = DictMock()
@@ -57,11 +60,13 @@ class TestObjects(unittest.TestCase):
         )
         self.assertEqual(
             "<class 'Submodule'> => {"
+            "'branch': None, 'ignore': None, "
             "'name': 'test_submodule', "
             "'parent_project': <class 'DictMock'> => {'id': 123456789}, "
             "'parent_ref': 'main', "
             "'path': 'include/test_submodule', "
-            "'url': 'git@gitlab.com:test/submodule'}",
+            "'recurse': False, 'shallow': False, "
+            "'update': None, 'url': 'git@gitlab.com:test/submodule'}",
             str(submodule)
         )
 
@@ -73,11 +78,13 @@ class TestObjects(unittest.TestCase):
             parent_ref='main',
             name='test_submodule',
             url='git@gitlab.com:test/submodule',
-            path='include/test_submodule'
+            path='include/test_submodule',
+            branch='development'
         )
         self.assertEqual(
             "Submodule ({'id': 123456789}, 'main', 'test_submodule',"
-            " 'include/test_submodule', 'git@gitlab.com:test/submodule')",
+            " 'include/test_submodule', 'git@gitlab.com:test/submodule',"
+            " 'development', None, None, False, False)",
             repr(submodule)
         )
 
@@ -157,7 +164,8 @@ class TestObjects(unittest.TestCase):
             parent_ref='main',
             name='test_submodule',
             url='git@gitlab.com:test/submodule',
-            path='include/test_submodule'
+            path='include/test_submodule',
+            branch = "development"
         )
         mock_project = DictMock()
         mock_project.name = 'project'
@@ -175,11 +183,13 @@ class TestObjects(unittest.TestCase):
         )
         self.assertEqual(
             "    'submodule': <class 'Submodule'> => {"
+            "'branch': 'development', 'ignore': None, "
             "'name': 'test_submodule', "
             "'parent_project': <class 'DictMock'> => {'id': '123456789'}, "
             "'parent_ref': 'main', "
             "'path': 'include/test_submodule', "
-            "'url': 'git@gitlab.com:test/submodule'},",
+            "'recurse': False, 'shallow': False, "
+            "'update': None, 'url': 'git@gitlab.com:test/submodule'},",
             str_lines[1]
         )
         self.assertEqual(
@@ -201,7 +211,8 @@ class TestObjects(unittest.TestCase):
             parent_ref='main',
             name='test_submodule',
             url='git@gitlab.com:test/submodule',
-            path='include/test_submodule'
+            path='include/test_submodule',
+            branch = "development"
         )
         mock_project = DictMock()
         mock_project.name = 'project'
@@ -218,9 +229,9 @@ class TestObjects(unittest.TestCase):
             str_lines[0]
         )
         self.assertEqual(
-            "    Submodule ({'id': '123456789'}, 'main', "
-            "'test_submodule', 'include/test_submodule', "
-            "'git@gitlab.com:test/submodule'),",
+            "    Submodule ({'id': '123456789'}, 'main', 'test_submodule',"
+            " 'include/test_submodule', 'git@gitlab.com:test/submodule',"
+            " 'development', None, None, False, False),",
             str_lines[1]
         )
         self.assertEqual(


### PR DESCRIPTION
- Adds all remaining .gitmodules "submodule" attributes to objects.Submodule: update, branch, ignore, shallow, fetchRecurseSubmodules (keyed as recurse)

- Modifies read_gitmodules._read_gitmodules_file_content to use configparser instead of regex to simplify matching optional keys

- Modifies any tests requiring direct Submodule instantiation, and adds a few extra arguments to test the extension