### PR TITLE
Catch Gitlab HTTP error for missing submodules

### DIFF
--- a/gitlab_submodule/gitlab_submodule.py
+++ b/gitlab_submodule/gitlab_submodule.py
@@ -2,6 +2,7 @@ from typing import Generator, List, Optional, Union
 
 from gitlab import Gitlab
 from gitlab.v4.objects import Project, ProjectManager
+from gitlab.exceptions import GitlabHttpError
 
 from gitlab_submodule.objects import Submodule, Subproject
 from gitlab_submodule.read_gitmodules import \
@@ -60,7 +61,7 @@ def iterate_subprojects(
             )
             if not (only_gitlab_subprojects and not subproject.project):
                 yield subproject
-        except FileNotFoundError:
+        except FileNotFoundError, GitlabHttpError:
             pass
 
 


### PR DESCRIPTION
Since Gitlab 17.4, for missing submodules (present in `.gitmodules` but not existing) Gitlab seems to report a GitlabHttpError instead of a previously raised FileNotFoundError. This is now caught.